### PR TITLE
Tile renaming causes inexitant references in animation

### DIFF
--- a/app.js
+++ b/app.js
@@ -894,7 +894,7 @@ app.component('stb-animation-frame', {
     spriteTile(sprite) {
       const tileset = this.tree.tileset;
       const idx = tileset.tilenames.indexOf(sprite.tile);
-      return tileset.tiles[idx];
+      return tileset.tiles[idx == -1 ? 0 : idx];
     },
 
     spriteStyle(sprite) {

--- a/app.js
+++ b/app.js
@@ -1507,10 +1507,21 @@ const TilesetTab = {
     },
 
     setSelectedTileName(ev) {
-      const name = ev.target.value;
+      const new_name = ev.target.value;
       const idx = this.selectedTileIndex;
       if (idx !== null) {
-        this.tree.tileset.tilenames[idx] = name;
+        const old_name = this.tree.tileset.tilenames[idx];
+        this.tree.tileset.tilenames[idx] = new_name;
+
+        Utils.getAnimationsUsingTile(this.tree, old_name).forEach(anim => {
+          anim.frames.forEach(frame => {
+            frame.sprites.forEach(sprite => {
+              if (sprite.tile == old_name) {
+                sprite.tile = new_name;
+              }
+            });
+          });
+        });
       }
     },
   },


### PR DESCRIPTION
There is certainly something smarter than the first commit, at least it avoids stb-mod-editor becoming unresponsive in this exact case (exceptions almost always cause the application to freeze.)