### PR TITLE
Handle start routine being nullable in character states

### DIFF
--- a/app.js
+++ b/app.js
@@ -1439,7 +1439,7 @@ app.component('stb-state', {
     <div class="stb-state">
       <i class="fas fa-chevron-down" @click="unroll = !unroll" /> <input v-model="state.name" /> <i class="fas fa-trash-alt" @click="$emit('delete')" />
       <ul v-show="unroll">
-        <li><label><span>Start routine:</span> <input v-model="state.start_routine" /></label></li>
+        <li><label><span>Start routine:</span> <input :value="state.start_routine" @change="state.start_routine = $event.target.value || null" /></label></li>
         <li><label><span>Update routine:</span> <input v-model="state.update_routine" /></label></li>
         <li><label><span>Input routine:</span> <input v-model="state.input_routine" /></label></li>
         <li><label><span>On ground routine:</span> <input v-model="state.onground_routine" /></label></li>
@@ -2039,7 +2039,7 @@ const CodeTab = {
       this.tree.states.push({
         type: 'character_state',
         name: 'STATE_NAME',
-        start_routine: 'dummy_routine',
+        start_routine: null,
         update_routine: 'dummy_routine',
         input_routine: 'dummy_routine',
         onground_routine: 'dummy_routine',


### PR DESCRIPTION
This is a weird trick in the mod format.

In character's state, the start routine is nullable. Actually, it must have a name for states `thrown`, `respawn`, `innexistant` and `spawn` and be `null` for all other states in order to be accepted by the mod compiler. Other routines are not nullable.

Details: the engine can force those states, so it needs to know their start routine. There is no need for other starts routines, so they do not appear in the jump table. Other state's routines (such has onground, onhurth...) can be called for any state, so their jump tables are complete.

No need to enforce all these rules. This patch simply puts `null` in the model when the field is empty. That's enough to be able to make compilable mods.