### PR TITLE
Draw highest priority sprites over lowest ones

### DIFF
--- a/app.js
+++ b/app.js
@@ -244,14 +244,14 @@ class Utils {
   }
 
   static drawSingleFrame(ctx, tree, frame, { zoom = 1, background, palettes, dx, dy }) {
-    for (let sprite of frame.sprites) {
+    for (let sprite of frame.sprites.toReversed()) {
       if (!sprite.foreground) {
         const x = sprite.x + dx;
         const y = sprite.y + dy;
         this.drawSingleSprite(ctx, tree, sprite, { zoom, palettes, x, y  });
       }
     }
-    for (let sprite of frame.sprites) {
+    for (let sprite of frame.sprites.toReversed()) {
       if (sprite.foreground) {
         const x = sprite.x + dx;
         const y = sprite.y + dy;


### PR DESCRIPTION
The NES works in reverse of framebuffers: first sprite takes priority over the following ones instead of the latter ones being drawn over the first. This PR reverses the sprites orders before drawing to emulate that.