### PR TITLE
Prevent flood fill tool crash

### DIFF
--- a/app.js
+++ b/app.js
@@ -356,6 +356,9 @@ class Utils {
 
   static floodFillTile(pixels, x, y, color) {
     let filled_color = pixels[y][x];
+    if (filled_color === color) {
+      return;
+    }
     let stack = [[x, y]];
     while (stack.length) {
       let [x, y] = stack.pop();


### PR DESCRIPTION
If you try to use the flood fill tool on a pixel that is already the same color, it will crash. This change prevents it.