### PR TITLE
Added multi character patching

### DIFF
--- a/data/mod.json
+++ b/data/mod.json
@@ -1,0 +1,15 @@
+{
+	"type": "gamemod",
+	"characters": [
+		{"type": "import", "src": "characters/sinbad/sinbad.json"},
+		{"type": "import", "src": "characters/kiki/kiki.json"},
+		{"type": "import", "src": "characters/pepper/pepper.json"},
+		{"type": "import", "src": "characters/vgsage/vgsage.json"},
+		{"type": "import", "src": "characters/sunny/sunny.json"}
+	],
+	"tilesets": [
+		{"type": "import", "src": "tilesets/ruins.json"},
+		{"type": "import", "src": "tilesets/jungle.json"},
+		{"type": "import", "src": "tilesets/magma.json"}
+	]
+}


### PR DESCRIPTION
Allows the user to patch any or all character slots at the same time, generate mod.json to build a ROM, and/or patch a loaded ROM (supporting both offline and online ROM versions). 

It no longer goes by the currently loaded character and a slot number input, which required the user to guess the slot that will be compatible. The user selects which characters they want to patch based on defaults loaded from the config.json, or any they have imported or saved. 
