### PR TITLE
Adapt illustration palette to STB 2.6

### DIFF
--- a/style.css
+++ b/style.css
@@ -497,8 +497,8 @@ div.sprite-info {
 
 .bg-illu-small-c0 { background-color: #000000; }
 .bg-illu-small-c1 { background-color: #C4C4C4; }
-.bg-illu-small-c2 { background-color: #FCD8A8; }
-.bg-illu-small-c3 { background-color: #9CFCF0; }
+.bg-illu-small-c2 { background-color: #00EBDB; }
+.bg-illu-small-c3 { background-color: #FCD8A8; }
 
 .bg-illu-large-c0 { background-color: #000000; }
 .bg-illu-large-c1 { background-color: #3CBCFC; }


### PR DESCRIPTION
Color 2 and 3 of the illustration palette are swapped, and more importantly, color 2 is now darker than color 3.